### PR TITLE
Removed illegal parameters from Upload Part call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,7 @@ Client.prototype.uploadFile = function(params) {
     var defaultContentType = params.defaultContentType || 'application/octet-stream';
     s3Params.ContentType = mime.lookup(localFile, defaultContentType);
   }
+  var sse = s3Params.ServerSideEncryption;
   var fatalError = false;
   var localFileSlicer = null;
   var parts = [];
@@ -222,10 +223,7 @@ Client.prototype.uploadFile = function(params) {
         Key: encodeSpecialCharacters(s3Params.Key),
         SSECustomerAlgorithm: s3Params.SSECustomerAlgorithm,
         SSECustomerKey: s3Params.SSECustomerKey,
-        SSECustomerKeyMD5: s3Params.SSECustomerKeyMD5,        
-        ServerSideEncryption: s3Params.ServerSideEncryption,
-        SSEKMSKeyId: s3Params.SSEKMSKeyId,
-        Metadata: s3Params.Metadata
+        SSECustomerKeyMD5: s3Params.SSECustomerKeyMD5
       };
       queueAllParts(data.UploadId, multipartUploadSize);
     });
@@ -318,7 +316,7 @@ Client.prototype.uploadFile = function(params) {
           }
           pend.wait(function() {
             if (fatalError) return;
-            if (s3Params.ServerSideEncryption !== 'aws:kms') {
+            if (sse !== 'aws:kms') {
               if (!compareMultipartETag(data.ETag, multipartETag)) {
                 errorOccurred = true;
                 uploader.progressAmount -= overallDelta;
@@ -416,7 +414,7 @@ Client.prototype.uploadFile = function(params) {
         }
         pend.wait(function() {
           if (fatalError) return;
-          if (s3Params.ServerSideEncryption !== 'aws:kms') {
+          if (sse !== 'aws:kms') {
             if (!compareMultipartETag(data.ETag, localFileStat.multipartETag)) {
               cb(new Error("ETag does not match MD5 checksum"));
               return;


### PR DESCRIPTION
I am using your branch because I need your fix which disables ETag verification when using SSE. However, I am getting this error from the AWS SDK when using multipart upload:

    There were 3 validation errors:
    * UnexpectedParameter: Unexpected key 'ServerSideEncryption' found in params
    * UnexpectedParameter: Unexpected key 'SSEKMSKeyId' found in params
    * UnexpectedParameter: Unexpected key 'Metadata' found in params

Amazon's docs for [Upload Part](https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html) state that the customer SSE parameters should be included for each part, but the other SSE parameters quoted above are not allowed. I have fixed the code so that it adheres to this spec.

NB: The parameters used in Upload Part are now the same ones passed in https://github.com/andrewrk/node-s3-client.